### PR TITLE
fix: ignition_hash reference in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,4 +6,6 @@ if [ ! -f id_rsa ]; then
 	curl -o id_rsa https://raw.githubusercontent.com/hashicorp/vagrant/master/keys/vagrant
 fi
 
-packer build -var-file vars.json fedora-coreos.pkr.hcl
+hash=$(sha256sum ignition-staticip.cfg | awk '{ print $1 }')
+
+packer build -var-file vars.json -var ignition_hash="sha256-$hash" fedora-coreos.pkr.hcl


### PR DESCRIPTION
After [commit 3470c3a](https://github.com/iquiw/packer-fedora-coreos/commit/3470c3ad1b1136cf45a4ca820201542be1729313), script `build.sh` doesn't work because variable `ignition_hash` is not set:

```lang-none
Error: Unset variable "ignition_hash"

A used variable must be set or have a default value; see
https://packer.io/docs/templates/hcl_templates/syntax for details.
```

